### PR TITLE
Updated rest-client version

### DIFF
--- a/3scale-cms.gemspec
+++ b/3scale-cms.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
                   download them from the CMS, upload the changes and create new files and templates.'
 
   s.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.2'
-  s.add_runtime_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_runtime_dependency 'rest-client', '~> 2.0.2', '>= 1.8.0'
   s.add_runtime_dependency 'liquid', '~> 3.0', '>= 3.0.6'
 
   s.required_ruby_version = '>= 2.0'


### PR DESCRIPTION
Had some trouble with SSL authentication on Windows 10, updated rest-client to 2.0.2 fixed the problem